### PR TITLE
Ensure dwas supports keyboard interrupts gracefully

### DIFF
--- a/src/dwas/_logging.py
+++ b/src/dwas/_logging.py
@@ -5,7 +5,7 @@ from contextvars import ContextVar
 from types import TracebackType
 from typing import Any, Optional, Tuple, Type, Union, cast
 
-from colorama import Fore, Style, init
+from colorama import Back, Fore, Style, init
 
 from ._log_capture import WriterProtocol
 
@@ -18,6 +18,7 @@ class ColorFormatter(logging.Formatter):
         logging.INFO: Fore.WHITE,
         logging.WARN: Fore.YELLOW,
         logging.ERROR: Fore.RED + Style.BRIGHT,
+        logging.FATAL: Back.RED + Fore.WHITE + Style.BRIGHT,
     }
 
     def formatMessage(self, record: logging.LogRecord) -> str:

--- a/src/dwas/_steps/handlers.py
+++ b/src/dwas/_steps/handlers.py
@@ -96,7 +96,11 @@ class StepHandler(BaseStepHandler):
         self._func = func
         step_environment = self._resolve_environ(passenv, setenv)
         self._venv_runner = VenvRunner(
-            self.name, self.python, self.config, step_environment
+            self.name,
+            self.python,
+            self.config,
+            step_environment,
+            proc_manager=self._pipeline.proc_manager,
         )
         self._step_runner = StepRunner(self)
 

--- a/src/dwas/_steps/steps.py
+++ b/src/dwas/_steps/steps.py
@@ -502,6 +502,8 @@ class StepRunner:
         if you wanted to move to conda.).
 
         :param packages: which packages to install
+        :raise KeyboardInterrupt: If the user has tried aborting the program and
+                                  is waiting for it to finish.
         """
         return self._handler.install(*packages)
 
@@ -517,7 +519,8 @@ class StepRunner:
         Run the provided command in the current environment.
 
         This method makes it's best to ensure the process' environment is
-        as isolated as possible.
+        as isolated as possible. It should be used whenever possible, instead
+        of calling :py:mod:`subprocess` directly.
 
         It will enforce that the first argument of the command is part of the
         python virtual environment that is specially created for the current
@@ -538,6 +541,8 @@ class StepRunner:
                                   succeeds, or show it every time.
         :return: a :py:class:`subprocess.CompletedProcess` with `stderr` and
                  `stdout` set to ``None``.
+        :raise KeyboardInterrupt: If the user has tried aborting the program and
+                                  is waiting for it to finish.
         """
         return self._handler.run(
             command,

--- a/src/dwas/_subproc.py
+++ b/src/dwas/_subproc.py
@@ -1,12 +1,14 @@
 import logging
 import os
 import pty
+import signal
 import subprocess
 import sys
+import time
 from contextlib import suppress
 from contextvars import ContextVar, copy_context
-from threading import Thread
-from typing import Dict, List
+from threading import Lock, Thread
+from typing import Any, Dict, List, Set
 
 from ._log_capture import PipePlexer, WriterProtocol
 
@@ -29,61 +31,130 @@ def _stream(source: int, dest: WriterProtocol) -> None:
             dest.write(data.decode())
 
 
-def run(
-    command: List[str], env: Dict[str, str], *, silent_on_success: bool = False
-) -> subprocess.CompletedProcess[None]:
-    LOGGER.debug("Running command: '%s'", " ".join(command))
+class ProcessManager:
+    def __init__(self) -> None:
+        self.processes: Set[subprocess.Popen[Any]] = set()
+        self._lock = Lock()
 
-    def _run() -> subprocess.CompletedProcess[None]:
-        p_stdin, c_stdin = pty.openpty()
-        p_stdout, c_stdout = pty.openpty()
-        p_stderr, c_stderr = pty.openpty()
+        self._was_killed = False
 
-        with subprocess.Popen(
-            command,
-            env=env,
-            text=True,
-            stdin=c_stdin,
-            stdout=c_stdout,
-            stderr=c_stderr,
-            close_fds=True,
-        ) as proc:
-            for fd in [c_stdin, c_stdout, c_stderr]:
+    def kill(self) -> None:
+        self._was_killed = True
+
+        with self._lock:
+            LOGGER.debug("Stopping %s processes", len(self.processes))
+            for proc in list(self.processes):
+                try:
+                    pgrp = os.getpgid(proc.pid)
+                except ProcessLookupError:
+                    # Process is dead, we are good
+                    self.processes.remove(proc)
+                    continue
+
+                os.killpg(pgrp, signal.SIGTERM)
+
+            # wait a maximum of 5 seconds for processes to quit
+            total_wait_time = 5.0
+
+            for proc in self.processes:
+                start = time.monotonic()
+
+                try:
+                    proc.wait(total_wait_time)
+                except subprocess.TimeoutExpired:
+                    break
+                total_wait_time -= time.monotonic() - start
+            else:
+                return  # All subprocesses exited
+
+            LOGGER.warning(
+                "Some processes took too long to finish, killing them."
+            )
+            for proc in self.processes:
+                try:
+                    pgrp = os.getpgid(proc.pid)
+                except ProcessLookupError:
+                    # Process is dead, we are good
+                    continue
+
+                os.killpg(pgrp, signal.SIGKILL)
+
+    def run(
+        self,
+        command: List[str],
+        env: Dict[str, str],
+        *,
+        silent_on_success: bool = False,
+    ) -> subprocess.CompletedProcess[None]:
+        LOGGER.debug("Running command: '%s'", " ".join(command))
+        if self._was_killed:
+            # Prevent starting new jobs if the program has been interrupted
+            raise KeyboardInterrupt()
+
+        def _run() -> subprocess.CompletedProcess[None]:
+            p_stdin, c_stdin = pty.openpty()
+            p_stdout, c_stdout = pty.openpty()
+            p_stderr, c_stderr = pty.openpty()
+
+            with subprocess.Popen(
+                command,
+                env=env,
+                text=True,
+                stdin=c_stdin,
+                stdout=c_stdout,
+                stderr=c_stderr,
+                close_fds=True,
+                start_new_session=True,
+            ) as proc:
+                self._add(proc)
+
+                for fd in [c_stdin, c_stdout, c_stderr]:
+                    os.close(fd)
+
+                stdout_reader = Thread(
+                    target=_stream, args=[p_stdout, _STDOUT_PIPE.get()]
+                )
+                stderr_reader = Thread(
+                    target=_stream, args=[p_stderr, _STDERR_PIPE.get()]
+                )
+
+                stdout_reader.start()
+                stderr_reader.start()
+
+                stdout_reader.join()
+                stderr_reader.join()
+
+            for fd in [p_stdin, p_stdout, p_stderr]:
                 os.close(fd)
 
-            stdout_reader = Thread(
-                target=_stream, args=[p_stdout, _STDOUT_PIPE.get()]
+            ret = subprocess.CompletedProcess[None](command, proc.returncode)
+            self._remove(proc)
+            ret.check_returncode()
+            return ret
+
+        if not silent_on_success:
+            return _run()
+
+        pipe_plexer = PipePlexer()
+
+        def _run_in_context() -> subprocess.CompletedProcess[None]:
+            set_subprocess_default_pipes(
+                pipe_plexer.stdout, pipe_plexer.stderr
             )
-            stderr_reader = Thread(
-                target=_stream, args=[p_stderr, _STDERR_PIPE.get()]
-            )
+            return _run()
 
-            stdout_reader.start()
-            stderr_reader.start()
+        context = copy_context()
 
-            stdout_reader.join()
-            stderr_reader.join()
+        try:
+            return context.run(_run_in_context)
+        except subprocess.CalledProcessError:
+            pipe_plexer.dump(sys.stdout, sys.stderr)
+            raise
 
-        for fd in [p_stdin, p_stdout, p_stderr]:
-            os.close(fd)
+    def _add(self, proc: subprocess.Popen[Any]) -> None:
+        with self._lock:
+            self.processes.add(proc)
 
-        ret = subprocess.CompletedProcess[None](command, proc.returncode)
-        ret.check_returncode()
-        return ret
-
-    if not silent_on_success:
-        return _run()
-
-    pipe_plexer = PipePlexer()
-
-    def _run_in_context() -> subprocess.CompletedProcess[None]:
-        set_subprocess_default_pipes(pipe_plexer.stdout, pipe_plexer.stderr)
-        return _run()
-
-    context = copy_context()
-
-    try:
-        return context.run(_run_in_context)
-    except subprocess.CalledProcessError:
-        pipe_plexer.dump(sys.stdout, sys.stderr)
-        raise
+    def _remove(self, proc: subprocess.Popen[Any]) -> None:
+        with self._lock:
+            self.processes.remove(proc)


### PR DESCRIPTION
One interrupt will prevent enqueuing new jobs and let the current ones finish.

A second one will go through them and kill them forcibly

Note that this does not do anything to prevent long running python code from keeping the focus, but there is not really a good solution against this.