### PR TITLE
Ensure the test cli runs in an isolated context and logging setup

### DIFF
--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -65,6 +65,8 @@ class Result:
     stderr: str
 
 
+@isolated_context
+@isolated_logging
 def execute(args: List[str], expected_status: int = 0) -> Result:
     """
     Runs dwas in an isolated context and returns the result from the run.


### PR DESCRIPTION
This fixes a regression introduced by 9917a2e665096eb961eaf1ec10073fd5e3d6b8ca