### PR TITLE
Use virtualenv instead of venv to generate virtual environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "pypy3.8"
 
     steps:
       - name: Check out repository

--- a/dwasfile.py
+++ b/dwasfile.py
@@ -7,7 +7,7 @@ REQUIREMENTS = "-rrequirements/requirements.txt"
 DOCS_REQUIREMENTS = "-rrequirements/requirements-docs.txt"
 TEST_REQUIREMENTS = "-rrequirements/requirements-test.txt"
 TYPES_REQUIREMENTS = "-rrequirements/requirements-types.txt"
-SUPPORTED_PYTHONS = ["3.8", "3.9", "3.10", "3.11"]
+SUPPORTED_PYTHONS = ["3.8", "3.9", "3.10", "3.11", "pypy3.8"]
 OLDEST_SUPPORTED_PYTHON = SUPPORTED_PYTHONS[0]
 PYTHON_FILES = [
     "docs/conf.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,10 @@ module = "tests.*"
 allow_untyped_defs = true
 allow_untyped_calls = true
 
+[[tool.mypy.overrides]]
+module = "virtualenv.*"
+ignore_missing_imports = true
+
 ##
 # Pylint
 [tool.pylint.main]

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,1 +1,2 @@
 colorama
+virtualenv

--- a/src/dwas/_pipeline.py
+++ b/src/dwas/_pipeline.py
@@ -480,7 +480,12 @@ class Pipeline:
                 scheduler.mark_failed(name, exc)
                 # FIXME: allow another exception that can be thrown programatically
                 exc_info = (
-                    exc if not isinstance(exc, CalledProcessError) else None
+                    exc
+                    if not isinstance(
+                        exc,
+                        (CalledProcessError, UnavailableInterpreterException),
+                    )
+                    else None
                 )
                 LOGGER.error(
                     "Step %s failed: %s",

--- a/src/dwas/_pipeline.py
+++ b/src/dwas/_pipeline.py
@@ -142,7 +142,7 @@ class Pipeline:
                 description=current_description,
                 func=func,
                 pipeline=self,
-                python=args.pop("python", None),
+                python_spec=args.pop("python", None),
                 requires=args.pop("requires", None),
                 run_by_default=current_run_by_default,
                 parameters=args,

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -1,4 +1,3 @@
-import sys
 from typing import Any, Dict, Optional
 
 import pytest
@@ -29,7 +28,8 @@ def _get_all_steps_from_pipeline(pipeline: Pipeline) -> Dict[str, Any]:
         parameters.pop("step")
 
         return {
-            "python": step.python,
+            # pylint: disable=protected-access
+            "python": step._venv_runner._installer._python_spec,
             "run_by_default": step.run_by_default,
             "requires": step.requires,
             "parameters": parameters,
@@ -47,8 +47,6 @@ def _expect_step(
     run_by_default: Optional[bool] = None,
     parameters: Dict[str, Any],
 ) -> Dict[str, Any]:
-    if python is None:
-        python = f"python{sys.version_info[0]}.{sys.version_info[1]}"
     if run_by_default is None:
         run_by_default = True
 
@@ -84,8 +82,6 @@ def test_can_register_step(pipeline, name, python, run_by_default):
 
     steps = _get_all_steps_from_pipeline(pipeline)
 
-    if python == "2.8":
-        python = "python2.8"
     if name is None:
         name = "noop"
 


### PR DESCRIPTION
While this adds a new dependency, it makes it easier to find python installations and versions, and allows us to add support for pypy and probably other python interpreters.