### PR TITLE
Add support for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,18 +79,22 @@ jobs:
           retention-days: 7
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs: package
 
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         python:
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
           - "pypy3.8"
+        include:
+          - os: windows-latest
+            python: "3.8"
 
     steps:
       - name: Check out repository

--- a/src/dwas/_config.py
+++ b/src/dwas/_config.py
@@ -158,25 +158,58 @@ class Config:
             sys.__stdout__.isatty() and sys.__stderr__.isatty()
         )
 
-        self.environ = {
-            # XXX: keep this list in sync with the above documentation
-            key: os.environ[key]
-            for key in [
-                "URL_CA_BUNDLE",
-                "PATH",
-                "LANG",
-                "LANGUAGE",
-                "LD_LIBRARY_PATH",
-                "PIP_INDEX_URL",
-                "PIP_EXTRA_INDEX_URL",
-                "PYTHONHASHSEED",
-                "REQUESTS_CA_BUNDLE",
-                "SSL_CERT_FILE",
-                "http_proxy",
-                "https_proxy",
-                "no_proxy",
-                "TMPDIR",
+        # XXX: keep this list in sync with the above documentation
+        passthrough_environment_variables = [
+            # System
+            "PATH",
+            "LANG",
+            "LANGUAGE",
+            "PYTHONHASHSEED",
+            "TMPDIR",
+            # Pip
+            "PIP_INDEX_URL",
+            "PIP_EXTRA_INDEX_URL",
+            # Proxies
+            "http_proxy",
+            "https_proxy",
+            "no_proxy",
+            # Certificates
+            "URL_CA_BUNDLE",
+            "REQUESTS_CA_BUNDLE",
+            "SSL_CERT_FILE",
+            # Compilation and such
+            "LD_LIBRARY_PATH",
+            "PKG_CONFIG",
+            "PKG_CONFIG_PATH",
+            "PKG_CONFIG_SYSROOT_DIR",
+        ]
+
+        # Windows needs a few more to work
+        if sys.platform == "win32":  # pragma: win32 cover
+            passthrough_environment_variables += [
+                # Needed to find VisualStudio for building wheels
+                "PROGRAMDATA",
+                "PROGRAMFILES(x86)",
+                "PROGRAMFILES",
+                # Required to be able to import c extensions (why?)
+                "SYSTEMDRIVE",
+                "SYSTEMROOT",
+                # Needed for the platform module to work
+                "PROCESSOR_ARCHITECTURE",
+                # Required by multiprocessing.cpu_count on windows
+                "NUMBER_OF_PROCESSORS",
+                # Temporary files directory
+                "TEMP",
+                "TMP",
+                # Needed for expanduser()
+                "USERPROFILE",
+                # Needed to discover executables
+                "PATHEXT",
             ]
+
+        self.environ = {
+            key: os.environ[key]
+            for key in passthrough_environment_variables
             if key in os.environ
         }
 

--- a/src/dwas/_frontend.py
+++ b/src/dwas/_frontend.py
@@ -13,8 +13,16 @@ from . import _io
 from ._scheduler import Scheduler
 from ._timing import format_timedelta
 
-ANSI_SHOW_CURSOR = f"{ansi.CSI}?25h"
-ANSI_HIDE_CURSOR = f"{ansi.CSI}?25l"
+# XXX: If colorama adds support, we could probably enable this
+#      https://github.com/tartley/colorama/issues/272
+if sys.platform == "win32":
+    # Don't support ANSI cursor hiding on windows for now, it can't be done
+    # with ansi codes
+    ANSI_HIDE_CURSOR = ""
+    ANSI_SHOW_CURSOR = ""
+else:
+    ANSI_HIDE_CURSOR = f"{ansi.CSI}?25l"
+    ANSI_SHOW_CURSOR = f"{ansi.CSI}?25h"
 
 
 class StepSummary:


### PR DESCRIPTION
This requires changing a few implementation details:

- Now fully resolve the command before launching it within the venv, otherwise, in some obscure cases, Windows would not find the executable
- Add more environment variables as passthrough, they are hard requirement in order to be able to run on windows
- Also add some missing PKG_CONFIG variables as we are reworking this area

fix #36 