### PR TITLE
Allow passing `cwd` to step.run

### DIFF
--- a/src/dwas/_runners.py
+++ b/src/dwas/_runners.py
@@ -118,6 +118,9 @@ class VenvRunner:
     def run(
         self,
         command: List[str],
+        cwd: Optional[
+            str | bytes | os.PathLike[str] | os.PathLike[bytes]
+        ] = None,
         env: Optional[Dict[str, str]] = None,
         external_command: bool = False,
         silent_on_success: bool = False,
@@ -127,6 +130,7 @@ class VenvRunner:
 
         return self._proc_manager.run(
             command,
+            cwd=cwd,
             env=env,
             silent_on_success=silent_on_success,
         )

--- a/src/dwas/_steps/handlers.py
+++ b/src/dwas/_steps/handlers.py
@@ -153,12 +153,16 @@ class StepHandler(BaseStepHandler):
         self,
         command: List[str],
         *,
+        cwd: Optional[
+            str | bytes | os.PathLike[str] | os.PathLike[bytes]
+        ] = None,
         env: Optional[Dict[str, str]] = None,
         external_command: bool = False,
         silent_on_success: bool = False,
     ) -> subprocess.CompletedProcess[None]:
         return self._venv_runner.run(
             command,
+            cwd=cwd,
             env=env,
             external_command=external_command,
             silent_on_success=silent_on_success,

--- a/src/dwas/_steps/steps.py
+++ b/src/dwas/_steps/steps.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 from typing import (
@@ -516,6 +517,9 @@ class StepRunner:
         self,
         command: List[str],
         *,
+        cwd: Optional[
+            str | bytes | os.PathLike[str] | os.PathLike[bytes]
+        ] = None,
         env: Optional[Dict[str, str]] = None,
         external_command: bool = False,
         silent_on_success: bool = False,
@@ -536,6 +540,7 @@ class StepRunner:
         To add more values, use `env`.
 
         :param command: The command to run, as a list of arguments.
+        :param cwd: The working directory in which to run the command.
         :param env: Additional environment variables to pass to the process.
                     Those will be merged on top of the :py:attr:`Config.environ`
                     values and can override them, but not remove them.
@@ -551,6 +556,7 @@ class StepRunner:
         """
         return self._handler.run(
             command,
+            cwd=cwd,
             env=env,
             external_command=external_command,
             silent_on_success=silent_on_success,

--- a/src/dwas/_subproc.py
+++ b/src/dwas/_subproc.py
@@ -9,7 +9,7 @@ import time
 from contextlib import suppress
 from contextvars import copy_context
 from threading import Lock, Thread
-from typing import Any, Dict, List, Set, TextIO
+from typing import Any, Dict, List, Optional, Set, TextIO
 
 from . import _io
 
@@ -74,6 +74,9 @@ class ProcessManager:
         self,
         command: List[str],
         env: Dict[str, str],
+        cwd: Optional[
+            str | bytes | os.PathLike[str] | os.PathLike[bytes]
+        ] = None,
         *,
         silent_on_success: bool = False,
     ) -> subprocess.CompletedProcess[None]:
@@ -85,6 +88,7 @@ class ProcessManager:
         def _run() -> subprocess.CompletedProcess[None]:
             with subprocess.Popen(
                 command,
+                cwd=cwd,
                 env=env,
                 text=True,
                 stdout=subprocess.PIPE,


### PR DESCRIPTION
This can be useful for programs that need to run in a specific directory.