### PR TITLE
lint: Configure ruff for this project and fix problems

### DIFF
--- a/.github/scripts/summary.py
+++ b/.github/scripts/summary.py
@@ -1,3 +1,4 @@
+# ruff: noqa:D100,D101,D102,D103,D105
 import argparse
 import logging
 from dataclasses import InitVar, dataclass, field
@@ -34,7 +35,7 @@ class TestCase:
             elif child.tag == "skipped":
                 state = "skipped"
             else:
-                assert False, f"unexpected tag: {child.tag}"
+                raise AssertionError(f"unexpected tag: {child.tag}")
 
             summary = child.attrib["message"].replace("\n", "<br />")
 
@@ -136,7 +137,9 @@ def main() -> None:
     testsuites = [
         TestSuite.from_junit(testsuite)
         for file in files
-        for testsuite in ElementTree.parse(file).findall("testsuite")
+        for testsuite in ElementTree.parse(file).findall(  # noqa: S314
+            "testsuite"
+        )
     ]
 
     summary = tabulate(
@@ -168,7 +171,7 @@ def main() -> None:
 
     errors = get_failures_and_errors(testsuites)
 
-    print(
+    print(  # noqa: T201
         f"""\
 ## Test suites
 

--- a/docs/_extensions/cleanup_signatures.py
+++ b/docs/_extensions/cleanup_signatures.py
@@ -4,6 +4,7 @@ from sphinx.application import Sphinx
 from sphinx.ext.autodoc import Options
 
 
+# ruff: noqa: ARG001
 def cleanup_signatures(  # pylint: disable=unused-argument
     app: Sphinx,
     what: str,

--- a/docs/_extensions/execute.py
+++ b/docs/_extensions/execute.py
@@ -11,7 +11,7 @@ from sphinx.application import Sphinx
 from sphinx.errors import ExtensionError
 
 
-class execute(nodes.Element):  # pylint: disable=invalid-name
+class execute(nodes.Element):  # pylint: disable=invalid-name  # noqa: N801
     pass
 
 
@@ -20,7 +20,10 @@ class ExecuteDirective(rst.Directive):
     final_argument_whitespace = True
     required_arguments = 1
 
-    option_spec = {"returncode": nonnegative_int, "cwd": unchanged}
+    option_spec = {  # noqa: RUF012
+        "returncode": nonnegative_int,
+        "cwd": unchanged,
+    }
 
     def run(self) -> List[nodes.Element]:
         env = self.state.document.settings.env
@@ -40,7 +43,8 @@ class ExecuteDirective(rst.Directive):
 
 
 def run_programs(
-    app: Sphinx, doctree: document  # pylint: disable=unused-argument
+    app: Sphinx,  # pylint: disable=unused-argument  # noqa: ARG001
+    doctree: document,
 ) -> None:
     env = os.environ.copy()
     # Ensure we always have colors set for the output

--- a/docs/_extensions/styles.py
+++ b/docs/_extensions/styles.py
@@ -15,12 +15,12 @@ fg_colors = bg_colors = {
 
 
 class AnsiMonokaiStyle(monokai.MonokaiStyle):
-    styles = dict(monokai.MonokaiStyle.styles)
+    styles = dict(monokai.MonokaiStyle.styles)  # noqa: RUF012
     styles.update(color_tokens(fg_colors, bg_colors))
     styles[pygments.token.Token.Color.Faint.Cyan] = "#0867AC"
 
 
 class AnsiDefaultStyle(default.DefaultStyle):
-    styles = dict(default.DefaultStyle.styles)
+    styles = dict(default.DefaultStyle.styles)  # noqa: RUF012
     styles.update(color_tokens(fg_colors, bg_colors))
     styles[pygments.token.Token.Color.Faint.Cyan] = "#0867AC"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ project = _project_metadata["Name"]
 release = _project_metadata["Version"]
 author = _project_metadata["Author-email"]
 # pylint: disable=redefined-builtin
-copyright = "2022, Benjamin Schubert"
+copyright = "2022, Benjamin Schubert"  # noqa: A001
 
 html_context = {
     "github_user": "BenjaminSchubert",

--- a/dwasfile.py
+++ b/dwasfile.py
@@ -1,3 +1,6 @@
+"""
+Contains the dwas configuration for this project.
+"""
 from pathlib import Path
 
 import dwas
@@ -226,5 +229,5 @@ dwas.register_step_group(
     "ci",
     ["docs", "format-check", "lint", "coverage", "twine:check"],
     "Run all checks that are run on CI",
-    False,
+    run_by_default=False,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,8 @@ disable = [
     "missing-class-docstring",
     "missing-function-docstring",
     "missing-module-docstring",
+    # Taken care of by ruff
+    "broad-exception-caught",
 ]
 
 [tool.pylint.variables]
@@ -133,7 +135,77 @@ disable = [
 # Ruff
 [tool.ruff]
 target-version = "py38"
+select = ["ALL"]
+ignore = [
+    ##
+    # Typing
+    "ANN101",  # Don't annotate 'self'
+    "ANN102",  # Don't annotate 'cls'
+    "ANN401",  # Allow typing with ANY
+    ##
+    # Format
+    "COM812",  # Don't put trailing commas everywhere
+    "E501",  # line length is handled by black
+    ##
+    # Docs
+    "D200",
+    "D203",
+    "D212",
+    "D404",
+    ##
+    # Stylistic decisions
+    "PLR0911",  # pylint too many return statements
+    "PLR0912",  # pylint too many branches
+    "PLR0913",  # pylint too many arguments
+    "PLR0915",  # pylint too many statements
+    "N818",  # we name exception as Exception not Error
+    "FIX",  # We want to put fixmes longterm
+    "TD",  # We want to be able to add todos without issu links
+    "INP001",  # Not every .py file is part of a package
+    "PT004",  # Don't add `_` in front of fixtures returning nothing
+    "S101",  # Allow asserts
+    "TID252",  # We want relative imports
+    "PLR2004",  # Disable magic numbers check
+    # Exception handling
+    "EM101",
+    "EM102",
+    "RSE102",
+    "TRY002",
+    "TRY003",
+    # We are not doing cryptographic stuff
+    "S311",
+    # This is buggy and doesnt' say how to validate
+    "S603",
+    # We want to be able tor rely on PATH and not hardcode binaries
+    "S607",
 
+    # FIXME: re-enable future annotations
+    "FA100",
+    # FIXME: re-enable upgrade rules
+    "UP",
+]
+
+flake8-pytest-style.parametrize-values-type = "tuple"
+flake8-pytest-style.parametrize-values-row-type = "tuple"
+flake8-pytest-style.fixture-parentheses = false
+lint.isort.known-first-party = ["dwas"]
+
+[tool.ruff.lint.per-file-ignores]
+"docs/*" = ["D"]
+"tests/*" = [
+    # No need to type annotate tests
+    "ANN",
+    # No need to document tests
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    # too many arguments, acceptable for tests
+    "PLR0913",
+    # Allow prints in tests
+    "T201",
+]
 
 
 ##

--- a/src/dwas/_config.py
+++ b/src/dwas/_config.py
@@ -127,6 +127,7 @@ class Config:
         verbosity: int,
         colors: Optional[bool],
         n_jobs: int,
+        *,
         skip_missing_interpreters: bool,
         skip_setup: bool,
         skip_run: bool,

--- a/src/dwas/_frontend.py
+++ b/src/dwas/_frontend.py
@@ -125,7 +125,7 @@ class Frontend:
         previous_summary_last_line_length = 0
         previous_line_length = None
 
-        def refresh(skip_summary: bool = False) -> None:
+        def refresh(*, skip_summary: bool = False) -> None:
             nonlocal previous_summary_height
             nonlocal previous_summary_last_line_length
             nonlocal previous_line_length
@@ -183,4 +183,4 @@ class Frontend:
             self._stop.wait(0.5)
             refresh()
 
-        refresh(True)
+        refresh(skip_summary=True)

--- a/src/dwas/_inspect.py
+++ b/src/dwas/_inspect.py
@@ -15,6 +15,6 @@ def get_location(obj: Any) -> str:
 def get_name(func: Callable[..., Any]) -> str:
     if inspect.isfunction(func):
         return func.__name__
-    actual_func = getattr(func, "__call__")
+    actual_func = func.__call__  # type: ignore[operator]
     func_name = actual_func.__name__
     return f"{func.__class__.__name__}.{func_name}"

--- a/src/dwas/_io.py
+++ b/src/dwas/_io.py
@@ -24,7 +24,7 @@ class NoOpWriter(io.TextIOWrapper):
     def __init__(self) -> None:
         pass
 
-    def read(self, size: Optional[int] = None) -> str:
+    def read(self, size: Optional[int] = None) -> str:  # noqa: ARG002
         raise io.UnsupportedOperation("Can't read from a noopwriter")
 
     def write(self, data: str) -> int:
@@ -41,7 +41,7 @@ class MemoryPipe(io.TextIOWrapper):
     ) -> None:
         self._writer = writer
 
-    def read(self, size: Optional[int] = None) -> str:
+    def read(self, size: Optional[int] = None) -> str:  # noqa: ARG002
         raise io.UnsupportedOperation("can't read from a memorypipe")
 
     def write(self, data: str) -> int:
@@ -52,7 +52,7 @@ class MemoryPipe(io.TextIOWrapper):
 
 
 class PipePlexer:
-    def __init__(self, write_on_flush: bool = True) -> None:
+    def __init__(self, *, write_on_flush: bool = True) -> None:
         self.stderr = MemoryPipe(self)
         self.stdout = MemoryPipe(self)
 
@@ -63,7 +63,9 @@ class PipePlexer:
         self._buffer.append((stream, data))
         return len(data)
 
-    def flush(self, force_write: bool = False) -> Optional[int]:
+    def flush(
+        self, force_write: bool = False  # noqa:FBT001,FBT002
+    ) -> Optional[int]:
         line = None
 
         if self._write_on_flush or force_write:
@@ -94,7 +96,7 @@ class StreamHandler(io.TextIOWrapper):
         self._var = var
         self._log_var = log_var
 
-    def read(self, size: Optional[int] = None) -> str:
+    def read(self, size: Optional[int] = None) -> str:  # noqa: ARG002
         raise io.UnsupportedOperation("can't read from a memorypipe")
 
     def write(self, data: str) -> int:

--- a/src/dwas/_logging.py
+++ b/src/dwas/_logging.py
@@ -1,6 +1,6 @@
 import logging
 from contextvars import ContextVar
-from types import TracebackType
+from types import MappingProxyType, TracebackType
 from typing import Any, Optional, TextIO, Tuple, Type, Union, cast
 
 from colorama import Back, Fore, Style, init
@@ -9,13 +9,18 @@ from ._io import ANSI_ESCAPE_CODE_RE
 
 
 class ColorFormatter(logging.Formatter):
-    COLOR_MAPPING = {
-        logging.DEBUG: Fore.CYAN,
-        logging.INFO: "",
-        logging.WARN: Fore.YELLOW,
-        logging.ERROR: Fore.RED + Style.BRIGHT,
-        logging.FATAL: Back.RED + Fore.WHITE + Style.BRIGHT,
-    }
+    # We need to follow camel case style
+    # ruff: noqa: N802
+
+    COLOR_MAPPING = MappingProxyType(
+        {
+            logging.DEBUG: Fore.CYAN,
+            logging.INFO: "",
+            logging.WARN: Fore.YELLOW,
+            logging.ERROR: Fore.RED + Style.BRIGHT,
+            logging.FATAL: Back.RED + Fore.WHITE + Style.BRIGHT,
+        }
+    )
 
     def formatMessage(self, record: logging.LogRecord) -> str:
         cast(Any, record).level_color = self.COLOR_MAPPING[record.levelno]
@@ -29,10 +34,7 @@ class ColorFormatter(logging.Formatter):
         ],
     ) -> str:
         output = super().formatException(ei)
-        output = f"{Fore.CYAN}\ndwas > " + "\ndwas > ".join(
-            output.splitlines()
-        )
-        return output
+        return f"{Fore.CYAN}\ndwas > " + "\ndwas > ".join(output.splitlines())
 
 
 class NoColorFormatter(logging.Formatter):
@@ -55,9 +57,10 @@ class ContextStreamHandler(logging.StreamHandler):  # type: ignore[type-arg]
 
 def setup_logging(
     level: int,
-    colors: bool,
     tty_output: ContextVar[TextIO],
     log_file: ContextVar[TextIO],
+    *,
+    colors: bool,
 ) -> None:
     nocolor_formatter = NoColorFormatter(
         fmt="dwas > [%(levelname)s] %(message)s"

--- a/src/dwas/_runners.py
+++ b/src/dwas/_runners.py
@@ -3,23 +3,28 @@ from __future__ import annotations
 import logging
 import os
 import shutil
-import subprocess
 import sys
 from contextlib import suppress
-from pathlib import Path
-from typing import Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Dict, List, Optional, cast
 
 from virtualenv import session_via_cli
-from virtualenv.run.session import Session
 
 from . import _io
-from ._config import Config
 from ._exceptions import (
     CommandNotFoundException,
     CommandNotInEnvironment,
     UnavailableInterpreterException,
 )
-from ._subproc import ProcessManager
+
+if TYPE_CHECKING:
+    import subprocess
+    from pathlib import Path
+
+    from virtualenv.run.session import Session
+
+    from ._config import Config
+    from ._subproc import ProcessManager
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -122,11 +127,14 @@ class VenvRunner:
             str | bytes | os.PathLike[str] | os.PathLike[bytes]
         ] = None,
         env: Optional[Dict[str, str]] = None,
+        *,
         external_command: bool = False,
         silent_on_success: bool = False,
     ) -> subprocess.CompletedProcess[None]:
         env = self._merge_env(self._config, env)
-        self._validate_command(command[0], external_command, env)
+        self._validate_command(
+            command[0], env, external_command=external_command
+        )
 
         return self._proc_manager.run(
             command,
@@ -151,7 +159,7 @@ class VenvRunner:
         return env
 
     def _validate_command(
-        self, command: str, external_command: bool, env: Dict[str, str]
+        self, command: str, env: Dict[str, str], *, external_command: bool
     ) -> None:
         cmd = shutil.which(command, path=env["PATH"])
 

--- a/src/dwas/_steps/handlers.py
+++ b/src/dwas/_steps/handlers.py
@@ -5,12 +5,10 @@ import itertools
 import logging
 import os
 import shutil
-import subprocess
 from abc import ABC, abstractmethod
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from .._config import Config
 from .._dependency_injection import call_with_parameters
 from .._exceptions import BaseDwasException
 from .._runners import VenvRunner
@@ -24,6 +22,9 @@ from .steps import (
 )
 
 if TYPE_CHECKING:
+    import subprocess
+
+    from .._config import Config
     from .._pipeline import Pipeline
 
 
@@ -140,7 +141,9 @@ class StepHandler(BaseStepHandler):
                 [
                     # Pylint check here is wrong, it's still an instance of our class
                     # pylint: disable=protected-access
-                    self._pipeline.get_step(requirement)._get_artifacts(key)
+                    self._pipeline.get_step(  # noqa: SLF001
+                        requirement
+                    )._get_artifacts(key)
                     for requirement in self.requires
                 ]
             )
@@ -184,7 +187,9 @@ class StepHandler(BaseStepHandler):
         for requirement in self.requires:
             # Pylint check here is wrong, it's still an instance of our class
             # pylint: disable=protected-access
-            self._pipeline.get_step(requirement)._execute_dependent_setup(self)
+            self._pipeline.get_step(  # noqa: SLF001
+                requirement
+            )._execute_dependent_setup(self)
 
         call_with_parameters(self._func, self.parameters.copy())
 
@@ -208,7 +213,7 @@ class StepHandler(BaseStepHandler):
                 self._step_runner,
                 # Pylint check here is wrong, it's still an instance of our class
                 # pylint: disable=protected-access
-                current_step._step_runner,
+                current_step._step_runner,  # noqa: SLF001
             )
 
     def _get_artifacts(self, key: str) -> List[Any]:
@@ -276,9 +281,9 @@ class StepGroupHandler(BaseStepHandler):
         for requirement in self.requires:
             # Pylint check here is wrong, it's still an instance of our class
             # pylint: disable=protected-access
-            self._pipeline.get_step(requirement)._execute_dependent_setup(
-                current_step
-            )
+            self._pipeline.get_step(  # noqa: SLF001
+                requirement
+            )._execute_dependent_setup(current_step)
 
     def _get_artifacts(self, key: str) -> List[Any]:
         return list(
@@ -286,7 +291,9 @@ class StepGroupHandler(BaseStepHandler):
                 [
                     # Pylint check here is wrong, it's still an instance of our class
                     # pylint: disable=protected-access
-                    self._pipeline.get_step(requirement)._get_artifacts(key)
+                    self._pipeline.get_step(  # noqa: SLF001
+                        requirement
+                    )._get_artifacts(key)
                     for requirement in self.requires
                 ]
             )

--- a/src/dwas/_steps/parametrize.py
+++ b/src/dwas/_steps/parametrize.py
@@ -68,14 +68,15 @@ class Parameter:
     # pylint: disable=protected-access
     @classmethod
     def merge(cls, param1: "Parameter", param2: "Parameter") -> "Parameter":
+        # ruff: noqa: SLF001
         if param1.id == "":
             id_ = param2.id
         elif param2.id == "":
             id_ = param1.id
         else:
-            id_ = ",".join([param1.id, param2.id])
+            id_ = f"{param1.id},{param2.id}"
 
-        for key in param2._parameters.keys():
+        for key in param2._parameters:
             if key in param1._parameters:
                 raise ValueError(key)
 
@@ -84,7 +85,7 @@ class Parameter:
 
         return cls(id_, joined_parameters)
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, type(self)):
             return NotImplemented
         return self.id == other.id and self._parameters == other._parameters
@@ -223,8 +224,8 @@ def parametrize(
             ids = [None] * len(args_values)
 
         current_parameters = [
-            Parameter(id, dict(zip(arg_names, args_values)))
-            for id, args_values in zip(ids, args_values)
+            Parameter(id_, dict(zip(arg_names, args_values)))
+            for id_, args_values in zip(ids, args_values)
         ]
 
         old_parameters = getattr(func, _PARAMETERS, [])

--- a/src/dwas/_steps/registration.py
+++ b/src/dwas/_steps/registration.py
@@ -206,7 +206,7 @@ def register_managed_step(
     def install(step: StepRunner, dependencies: str) -> None:
         step.install(*dependencies)
 
-    setattr(func, "setup", install)
+    func.setup = install  # type: ignore[attr-defined]
     if dependencies is not None:
         func = parametrize("dependencies", [dependencies])(func)
 

--- a/src/dwas/_steps/steps.py
+++ b/src/dwas/_steps/steps.py
@@ -3,9 +3,7 @@
 
 from __future__ import annotations
 
-import os
-import subprocess
-from pathlib import Path
+from pathlib import Path  # noqa: TCH003  required for Sphinx
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -17,9 +15,11 @@ from typing import (
     runtime_checkable,
 )
 
-from .._config import Config
-
 if TYPE_CHECKING:
+    import os
+    import subprocess
+
+    from .._config import Config
     from .handlers import StepHandler
 
 
@@ -94,7 +94,7 @@ class Step(Protocol):
 
             For passing other arguments, see :py:func:`dwas.parametrize` and
             :py:func:`dwas.set_defaults`.
-        """
+        """  # noqa: D401
 
 
 @runtime_checkable

--- a/src/dwas/predefined/__init__.py
+++ b/src/dwas/predefined/__init__.py
@@ -1,6 +1,5 @@
 """
-This module contains predefined steps that are provided in order to help reduce
-duplication.
+This module contains common predefined steps to help reduce duplication.
 
 .. note::
 

--- a/src/dwas/predefined/_package.py
+++ b/src/dwas/predefined/_package.py
@@ -61,7 +61,7 @@ class Package(StepWithDependentSetup):
             silent_on_success=current_step.config.verbosity < 2,
         )
 
-    def __call__(self, step: StepRunner, isolate: bool) -> None:
+    def __call__(self, step: StepRunner, *, isolate: bool) -> None:
         with suppress(FileNotFoundError):
             shutil.rmtree(step.cache_path)
 

--- a/src/dwas/predefined/_pylint.py
+++ b/src/dwas/predefined/_pylint.py
@@ -27,7 +27,7 @@ class Pylint(Step):
         if step.config.colors and not [
             p
             for p in additional_arguments
-            if p.startswith("--output-format") or p.startswith("-f")
+            if p.startswith(("--output-format", "-f"))
         ]:
             additional_arguments.append("--output-format=colorized")
 

--- a/src/dwas/predefined/_sphinx.py
+++ b/src/dwas/predefined/_sphinx.py
@@ -30,6 +30,7 @@ class Sphinx(Step):
         builder: str,
         sourcedir: Union[Path, str],
         output: Optional[Union[Path, str]],
+        *,
         warning_as_error: bool,
     ) -> None:
         if step.config.verbosity == -2:

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -51,8 +51,7 @@ def isolated_logging() -> Iterator[None]:
 def using_project(project: str) -> Callable[[_T], _T]:
     def wrapper(func):
         func = pytest.mark.project(TESTS_PATH / project)(func)
-        func = pytest.mark.usefixtures("project")(func)
-        return func
+        return pytest.mark.usefixtures("project")(func)
 
     return wrapper
 
@@ -67,7 +66,7 @@ class Result:
 @isolated_context
 def execute(args: List[str], expected_status: int = 0) -> Result:
     """
-    Runs dwas in an isolated context and returns the result from the run.
+    Run dwas in an isolated context and returns the result from the run.
 
     In most cases, you'll want to use the below `cli` instead, which
     will take care of building the cli correctly for you.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ def pytest_collection_modifyitems(items):
     for item in items:
         try:
             item.path.relative_to(predefined_tests_path)
-        except ValueError:
+        except ValueError:  # noqa:PERF203
             continue
         else:
             item.add_marker(pytest.mark.predefined)

--- a/tests/predefined/mixins.py
+++ b/tests/predefined/mixins.py
@@ -10,6 +10,12 @@ COLOR_ESCAPE_CODE = re.compile(r"\x1b\[\d+m")
 
 
 class BaseStepTest(ABC):
+    @abstractmethod
+    def expected_output(self) -> str:
+        """
+        Get part of the expected output for the run.
+        """
+
     @pytest.fixture(scope="module")
     def cache_path(self, tmp_path_factory):
         return tmp_path_factory.mktemp("cache")
@@ -20,7 +26,7 @@ class BaseStepTest(ABC):
         assert expected_output in result.stdout
 
     @pytest.mark.parametrize(
-        "enable_colors", [True, False], ids=["colors", "no-colors"]
+        "enable_colors", (True, False), ids=["colors", "no-colors"]
     )
     @pytest.mark.usefixtures("project")
     def test_respects_color_settings(self, cache_path, enable_colors):
@@ -61,7 +67,7 @@ class BaseLinterTest(ABC):
     def cache_path(self, tmp_path_factory):
         return tmp_path_factory.mktemp("cache")
 
-    def _make_project(self, path: Path, valid: bool = True) -> None:
+    def _make_project(self, path: Path, *, valid: bool = True) -> None:
         path.joinpath("dwasfile.py").write_text(self.dwasfile)
 
         token_file = path.joinpath("src/token.py")
@@ -72,14 +78,14 @@ class BaseLinterTest(ABC):
             token_file.write_text(self.invalid_file)
 
     @pytest.mark.parametrize(
-        "valid", [True, False], ids=["valid-project", "invalid-project"]
+        "valid", (True, False), ids=["valid-project", "invalid-project"]
     )
     def test_simple_behavior(self, cache_path, tmp_path, valid):
         self._make_project(tmp_path, valid=valid)
         cli(cache_path=cache_path, expected_status=0 if valid else 1)
 
     @pytest.mark.parametrize(
-        "enable_colors", [True, False], ids=["colors", "no-colors"]
+        "enable_colors", (True, False), ids=["colors", "no-colors"]
     )
     def test_respects_color_settings(
         self, cache_path, tmp_path, enable_colors

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,3 +1,5 @@
+# This tests some internals
+# ruff: noqa:SLF001
 from datetime import timedelta
 
 import pytest
@@ -199,7 +201,12 @@ def test_graph_computation_is_correct(
     pipeline.register_step("step-1-3-1", None, func())
 
     # pylint: disable=protected-access
-    assert pipeline._build_graph(steps, except_steps, only_selected) == result
+    assert (
+        pipeline._build_graph(
+            steps, except_steps, only_selected_steps=only_selected
+        )
+        == result
+    )
 
 
 def test_only_keeps_dependency_information(pipeline):
@@ -209,10 +216,9 @@ def test_only_keeps_dependency_information(pipeline):
     pipeline.register_step("4", None, func())
 
     # pylint: disable=protected-access
-    assert pipeline._build_graph(["1", "4"], None, True) == {
-        "1": ["4"],
-        "4": [],
-    }
+    assert pipeline._build_graph(
+        ["1", "4"], None, only_selected_steps=True
+    ) == {"1": ["4"], "4": []}
 
 
 def test_exclude_keeps_dependency_information(pipeline):
@@ -222,13 +228,12 @@ def test_exclude_keeps_dependency_information(pipeline):
     pipeline.register_step("4", None, func())
 
     # pylint: disable=protected-access
-    assert pipeline._build_graph(None, ["2", "3"], False) == {
-        "1": ["4"],
-        "4": [],
-    }
+    assert pipeline._build_graph(
+        None, ["2", "3"], only_selected_steps=False
+    ) == {"1": ["4"], "4": []}
 
 
-@pytest.mark.parametrize("step_type", ["normal", "group"])
+@pytest.mark.parametrize("step_type", ("normal", "group"))
 def test_cannot_register_two_step_with_same_name(pipeline, step_type):
     pipeline.register_step("step", None, func())
     if step_type == "group":

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -1,3 +1,5 @@
+# This tests some internals
+# ruff: noqa:SLF001
 from typing import Any, Dict, Optional
 
 import pytest
@@ -132,7 +134,7 @@ def test_handles_step_with_no_name(pipeline):
 
 
 @pytest.mark.parametrize(
-    "from_parameters", [True, False], ids=["from_parameters", "direct"]
+    "from_parameters", (True, False), ids=["from_parameters", "direct"]
 )
 @isolated_context
 def test_can_register_managed_step(pipeline, from_parameters):


### PR DESCRIPTION
Most notable are:

- require boolean arguments to be passed as keywords

Otherwise it can't be quite confusing and ordering becomes less clear.
Overall this reduces errors

- Ensure all imports used for typechecking are guarded by TYPE_CHECKING