### PR TITLE
Simplify the linters run by using the current version to run and target the right one

### DIFF
--- a/.github/scripts/summary.py
+++ b/.github/scripts/summary.py
@@ -22,7 +22,7 @@ class TestCase:
 
     @classmethod
     def from_junit(cls, tree: ET.Element) -> TestCase:
-        children = tree.getchildren()
+        children = list(tree)
         assert len(children) <= 1
 
         state: Literal["success", "failure", "error", "skipped"] = "success"
@@ -171,8 +171,7 @@ def main() -> None:
 
     errors = get_failures_and_errors(testsuites)
 
-    print(  # noqa: T201
-        f"""\
+    print(f"""\
 ## Test suites
 
 {summary}
@@ -182,8 +181,7 @@ def main() -> None:
 {slowest_tests}
 
 {errors}
-"""
-    )
+""")  # noqa: T201
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 name: Checks
 
 env:
-  DEFAULT_PYTHON: 3.8
+  DEFAULT_PYTHON: 3.13
   PACKAGES_PATH: .dwas/cache/package/
   COVERAGE_FILES_PATH: .dwas/cache/pytest-*/reports/coverage
   JUNIT_REPORT_PATH: _artifacts/junit/
@@ -44,7 +44,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
+          python-version: ${{ matrix.session == 'mypy' && '3.8' || env.DEFAULT_PYTHON }}
           cache: pip
 
       # FIXME: we should take dwas from pypi once it's published

--- a/dwasfile.py
+++ b/dwasfile.py
@@ -21,7 +21,6 @@ SUPPORTED_PYTHONS = [
     "3.14",
     "pypy3.11",
 ]
-OLDEST_SUPPORTED_PYTHON = SUPPORTED_PYTHONS[0]
 PYTHON_FILES = [
     "docs/conf.py",
     "docs/_extensions",
@@ -48,9 +47,7 @@ dwas.register_managed_step(
     dwas.predefined.docformatter(files=PYTHON_FILES),
     dependencies=["docformatter[tomli]"],
 )
-dwas.register_managed_step(
-    dwas.predefined.black(), python=OLDEST_SUPPORTED_PYTHON
-)
+dwas.register_managed_step(dwas.predefined.black())
 dwas.register_step_group(
     "format-check", ["black", "docformatter", "isort", "unimport"]
 )
@@ -86,7 +83,6 @@ dwas.register_managed_step(
 dwas.register_managed_step(
     dwas.predefined.black(additional_arguments=[]),
     name="black:fix",
-    python=OLDEST_SUPPORTED_PYTHON,
     requires=["isort:fix", "docformatter:fix"],
     run_by_default=False,
 )
@@ -125,7 +121,7 @@ dwas.register_managed_step(
         TEST_REQUIREMENTS,
         TYPES_REQUIREMENTS,
     ],
-    python=OLDEST_SUPPORTED_PYTHON,
+    python=SUPPORTED_PYTHONS[0],
 )
 dwas.register_managed_step(
     dwas.predefined.pylint(files=PYTHON_FILES),
@@ -136,12 +132,10 @@ dwas.register_managed_step(
         "pylint",
         "tabulate",
     ],
-    python=OLDEST_SUPPORTED_PYTHON,
 )
 dwas.register_managed_step(
     dwas.predefined.ruff(files=PYTHON_FILES),
     dependencies=["ruff"],
-    python=OLDEST_SUPPORTED_PYTHON,
 )
 dwas.register_step_group("lint", ["mypy", "pylint", "ruff"])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ optional-dependencies.docs.file = "requirements/requirements-docs.txt"
 # Black
 [tool.black]
 line-length = 79
+target-version = ["py38"]
 
 ##
 # Docformatter
@@ -106,6 +107,7 @@ ignore_missing_imports = true
 ##
 # Pylint
 [tool.pylint.main]
+py-version = "3.8"
 load-plugins = "pylint.extensions.docparams"
 
 [tool.pylint.format]


### PR DESCRIPTION
This makes it easier to run linters locally, as 3.8 is really ancient. Maybbe we should just drop it at this point