### PR TITLE
Fix the scheduler to not fail in some cases due to ordering of the set of dependencies

### DIFF
--- a/src/dwas/_exceptions.py
+++ b/src/dwas/_exceptions.py
@@ -46,7 +46,7 @@ class FailedPipelineException(BaseDwasException):
 
 
 class UnknownStepsException(BaseDwasException):
-    def __init__(self, steps: list[str]) -> None:
+    def __init__(self, steps: set[str]) -> None:
         message = f"Unknown steps: {', '.join(steps)}"
         super().__init__(message)
 

--- a/src/dwas/_pipeline.py
+++ b/src/dwas/_pipeline.py
@@ -206,7 +206,7 @@ class Pipeline:
 
         graph = {}
         steps_to_process = deque(steps)
-        unknown_steps = []
+        unknown_steps = set()
 
         while steps_to_process:
             step = steps_to_process.pop()
@@ -214,7 +214,7 @@ class Pipeline:
             try:
                 step_info = self.steps[step]
             except KeyError:
-                unknown_steps.append(step)
+                unknown_steps.add(step)
                 continue
 
             graph[step] = step_info.requires

--- a/src/dwas/_scheduler.py
+++ b/src/dwas/_scheduler.py
@@ -106,7 +106,7 @@ class Scheduler:
                     self.ready.append(dependent)
 
     def _mark_dependents_blocked(self, step: str) -> None:
-        for dependent in self._dependents_graph[step]:
+        for dependent in sorted(self._dependents_graph[step]):
             try:
                 self.waiting.remove(dependent)
             except KeyError:
@@ -120,7 +120,7 @@ class Scheduler:
 
             # Remove this dependent from all it's dependencies, we will never
             # be able to start it anyways
-            for dependency in dependencies:
+            for dependency in sorted(dependencies):
                 self._dependents_graph[dependency].remove(dependent)
 
             # And finally recurse

--- a/src/dwas/_steps/registration.py
+++ b/src/dwas/_steps/registration.py
@@ -299,7 +299,7 @@ def step(
 
 
 def managed_step(
-    dependencies: Sequence[str],
+    dependencies: Sequence[str] | None,
     *,
     name: str | None = None,
     description: str | None = None,


### PR DESCRIPTION
Sometimes it would fail due to the order of the set leading to edition of the list being processed. This ensures that we're not modifying the list and always process is in the same order