### PR TITLE
Add tests to validate how the installation of dependencies works

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,8 @@ isort.known-first-party = ["dwas"]
     "D102",
     "D103",
     "D104",
+    "D105",
+    "D107",
     # too many arguments, acceptable for tests
     "PLR0913",
     # Allow prints in tests

--- a/tests/examples/dependencies/dwasfile.py
+++ b/tests/examples/dependencies/dwasfile.py
@@ -1,0 +1,20 @@
+import dwas
+import dwas.predefined
+
+dwas.register_managed_step(dwas.predefined.package())
+
+
+@dwas.managed_step(None)
+@dwas.parametrize("requires", (["package"], []), ids=("package", "no-package"))
+@dwas.parametrize(
+    "dependencies",
+    (
+        ["--requirements=pyproject.toml"],
+        ["--group=dev"],
+        ["--group=other"],
+        ["--group=dev", "--group=other", "--requirements=pyproject.toml"],
+    ),
+    ids=("pyproject", "dev-group", "other-group", "all"),
+)
+def dependencies(step: dwas.StepRunner) -> None:
+    step.run(["uv", "pip", "list", "--format=json"], external_command=True)

--- a/tests/examples/dependencies/pyproject.toml
+++ b/tests/examples/dependencies/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "test-dependencies"
+version = "0.0.1"
+requires-python = ">=3.8"
+dependencies = ["colorama"]
+
+[dependency-groups]
+dev = ["pip"]
+other = ["setuptools"]

--- a/tests/examples/dependencies/uv.lock
+++ b/tests/examples/dependencies/uv.lock
@@ -1,0 +1,53 @@
+version = 1
+revision = 3
+requires-python = ">=3.8"
+
+[[package]]
+name = "colorama"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/d5/c35bd3e63757ac767105f8695b055581d8b8dd8c22fef020ebefa2a3725d/colorama-0.4.0.zip", hash = "sha256:c9b54bebe91a6a803e0772c8561d53f2926bfeb17cd141fbabcb08424086595c", size = 37521, upload-time = "2018-10-10T14:47:13.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/93/6e8289231675d561d476d656c2ee3a868c1cca207e16c118d4503b25e2bf/colorama-0.4.0-py2.py3-none-any.whl", hash = "sha256:a3d89af5db9e9806a779a50296b5fdb466e281147c2c235e8225ecc6dbf7bbf3", size = 21204, upload-time = "2018-10-10T14:47:29.452Z" },
+]
+
+[[package]]
+name = "pip"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/3e/68beeeeb306ea20ffd30b3ed993f531d16cd884ec4f60c9b1e238f69f2af/pip-25.0.tar.gz", hash = "sha256:8e0a97f7b4c47ae4a494560da84775e9e2f671d415d8d828e052efefb206b30b", size = 1950328, upload-time = "2025-01-26T12:40:41.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/8a/1ddf40be20103bcc605db840e9ade09c8e8c9f920a03e9cfe88eae97a058/pip-25.0-py3-none-any.whl", hash = "sha256:b6eb97a803356a52b2dd4bb73ba9e65b2ba16caa6bcb25a7497350a4e5859b65", size = 1841506, upload-time = "2025-01-26T12:40:39.243Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "70.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/60/5db2249526c9b453c5bb8b9f6965fcab0ddb7f40ad734420b3b421f7da44/setuptools-70.0.0.tar.gz", hash = "sha256:f211a66637b8fa059bb28183da127d4e86396c991a942b028c6650d4319c3fd0", size = 2265182, upload-time = "2024-05-21T10:28:18.891Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/88/70c5767a0e43eb4451c2200f07d042a4bcd7639276003a9c54a68cfcc1f8/setuptools-70.0.0-py3-none-any.whl", hash = "sha256:54faa7f2e8d2d11bcd2c07bed282eef1046b5c080d1c32add737d7b5817b1ad4", size = 863432, upload-time = "2024-05-21T10:28:12.781Z" },
+]
+
+[[package]]
+name = "test-dependencies"
+version = "0.0.1"
+source = { virtual = "." }
+dependencies = [
+    { name = "colorama" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pip" },
+]
+other = [
+    { name = "setuptools" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "colorama", specifier = "==0.4.0" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pip", specifier = "==25.0" }]
+other = [{ name = "setuptools", specifier = "==70.0.0" }]

--- a/tests/test_dependencies_installation.py
+++ b/tests/test_dependencies_installation.py
@@ -1,0 +1,99 @@
+# pylint: disable=redefined-outer-name
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests._utils import cli, using_project
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class GreaterThan:
+    def __init__(self, version: str) -> None:
+        self._expected_version = version
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, str):
+            return NotImplemented
+
+        expected_parts = self._expected_version.split(".")
+        other_parts = other.split(".")
+
+        len_diff = len(expected_parts) - len(other_parts)
+        if len_diff < 0:
+            expected_parts += ["0"] * -len_diff
+        elif len_diff > 0:
+            other_parts += ["0"] * len_diff
+
+        for e, o in zip(expected_parts, other_parts):
+            ei = int(e)
+            oi = int(o)
+
+            if ei > oi:
+                return False
+            if ei < oi:
+                return True
+
+        return False
+
+    def __hash__(self) -> int:
+        return hash((self.__class__.__name__, self._expected_version))
+
+    def __repr__(self) -> str:
+        return f"GreaterThan<{self._expected_version}>"
+
+
+@pytest.fixture(scope="module")
+def cache_path(tmp_path_factory):
+    return tmp_path_factory.mktemp("cache")
+
+
+@pytest.mark.parametrize(
+    ("dependencies_name", "expected_packages"),
+    (
+        ("pyproject", {"colorama": "0.4.0"}),
+        ("dev-group", {"pip": "25.0"}),
+        ("other-group", {"setuptools": "70.0.0"}),
+        ("all", {"colorama": "0.4.0", "pip": "25.0", "setuptools": "70.0.0"}),
+    ),
+    ids=["pyproject", "dev-group", "other-group", "all"],
+)
+@pytest.mark.parametrize(
+    "package", (True, False), ids=["package", "no-package"]
+)
+@using_project("examples/dependencies")
+def test_only_selected_dependencies_are_installed(
+    cache_path: Path,
+    tmp_path: Path,
+    dependencies_name: str,
+    package: bool,  # noqa: FBT001
+    expected_packages: dict[str, str],
+) -> None:
+    step_name = f"dependencies[{'no-' if not package else ''}package,{dependencies_name}]"
+    original_lock = tmp_path.joinpath("uv.lock").read_text()
+
+    result = cli(cache_path=cache_path, steps=[step_name])
+    dependencies = json.loads(result.stdout.strip().splitlines()[-1])
+    final_lock = tmp_path.joinpath("uv.lock").read_text()
+
+    expected_installs = [
+        {"name": pkg, "version": GreaterThan(version)}
+        for pkg, version in expected_packages.items()
+    ]
+    if package:
+        if expected_installs[0]["name"] != "colorama":
+            expected_installs = [
+                {"name": "colorama", "version": GreaterThan("0.4.0")},
+                *expected_installs,
+            ]
+        expected_installs.append(
+            {"name": "test-dependencies", "version": "0.0.1"}
+        )
+
+    assert dependencies == expected_installs
+    assert final_lock == original_lock


### PR DESCRIPTION
This ensures that in the current state of affairs, lockfiles are not respected