### PR TITLE
Allow installing pinned dependencies using a lockfile

### DIFF
--- a/src/dwas/_runners.py
+++ b/src/dwas/_runners.py
@@ -71,10 +71,22 @@ class VenvRunner:
     def install(
         self,
         *packages: str,
+        sync: bool = False,
         no_deps: bool = False,
         force_reinstall: bool = False,
     ) -> None:
-        command = [self._uv, "pip", "install"]
+        if sync:
+            command = [
+                self._uv,
+                "sync",
+                "--frozen",
+                "--no-install-project",
+                "--no-default-groups",
+                "--active",
+            ]
+        else:
+            command = [self._uv, "pip", "install"]
+
         if no_deps:
             command.append("--no-deps")
         if force_reinstall:

--- a/src/dwas/_steps/handlers.py
+++ b/src/dwas/_steps/handlers.py
@@ -158,11 +158,15 @@ class StepHandler(BaseStepHandler):
     def install(
         self,
         *packages: str,
+        sync: bool = False,
         no_deps: bool = False,
         force_reinstall: bool = False,
     ) -> None:
         self._venv_runner.install(
-            *packages, no_deps=no_deps, force_reinstall=force_reinstall
+            *packages,
+            sync=sync,
+            no_deps=no_deps,
+            force_reinstall=force_reinstall,
         )
 
     def run(

--- a/src/dwas/_steps/registration.py
+++ b/src/dwas/_steps/registration.py
@@ -161,6 +161,7 @@ def register_managed_step(
     func: Step,
     dependencies: Sequence[str] | None = None,
     *,
+    dependencies_sync: bool | None = None,
     name: str | None = None,
     description: str | None = None,
     python: str | None = None,
@@ -185,6 +186,10 @@ def register_managed_step(
     :param dependencies: A list of dependencies to install as a setup phase.
                          If :python:`None`, will expect a :python:`dependencies`
                          parameter to be passed via :py:func:`parametrize`.
+    :param dependencies_sync: Use `uv sync` when dealing with dependencies
+                              instead of `pip install`.
+                              See :py:func:`StepRunner.install` for examples
+                              and details.
     :param name: The name to give to the step.
                  Defaults to :python:`func.__name__`
     :param description: An optional description of what the current step does
@@ -207,12 +212,19 @@ def register_managed_step(
         )
 
     # pylint: disable=redefined-outer-name
-    def install(step: StepRunner, dependencies: str) -> None:
-        step.install(*dependencies)
+    def install(
+        step: StepRunner,
+        dependencies: list[str],
+        *,
+        dependencies_sync: bool = False,
+    ) -> None:
+        step.install(*dependencies, sync=dependencies_sync)
 
     func.setup = install  # type: ignore[attr-defined]
     if dependencies is not None:
         func = parametrize("dependencies", [dependencies])(func)
+    if dependencies_sync is not None:
+        func = parametrize("dependencies_sync", [dependencies_sync])(func)
 
     return register_step(
         func,
@@ -301,6 +313,7 @@ def step(
 def managed_step(
     dependencies: Sequence[str] | None,
     *,
+    dependencies_sync: bool | None = None,
     name: str | None = None,
     description: str | None = None,
     python: str | None = None,
@@ -316,6 +329,12 @@ def managed_step(
     the decorated object.
 
     :param dependencies: A list of dependencies to install as a setup phase.
+                         If :python:`None`, will expect a :python:`dependencies`
+                         parameter to be passed via :py:func:`parametrize`.
+    :param dependencies_sync: Use `uv sync` when dealing with dependencies
+                              instead of `pip install`.
+                              See :py:func:`StepRunner.install` for examples
+                              and details.
     :param name: The name used to refer to this step
     :param description: An optional description of what the current step does
     :param python: The python version to use in this step
@@ -330,6 +349,7 @@ def managed_step(
         register_managed_step(
             func,
             dependencies,
+            dependencies_sync=dependencies_sync,
             name=name,
             description=description,
             python=python,

--- a/src/dwas/_steps/steps.py
+++ b/src/dwas/_steps/steps.py
@@ -488,6 +488,7 @@ class StepRunner:
     def install(
         self,
         *packages: str,
+        sync: bool = False,
         no_deps: bool = False,
         force_reinstall: bool = False,
     ) -> None:
@@ -499,7 +500,50 @@ class StepRunner:
         handle the details when changing the type of virtual environment (e.g.
         if you wanted to move to conda.).
 
+        :Examples:
+
+        Here's a few ways of installing packages depending on what you want.
+
+        .. code-block::
+
+            ##
+            # Without syncing files
+            ##
+
+            # Install a single package
+            step.install(["mypy"])
+
+            # Install dependencies from a requirements.txt file
+            step.install(["--requirements=requirements.txt"])
+
+            # Install only the package's dependencies but not the package
+            step.install(["--requirements=pyproject.toml"])
+
+            # Install the current package (See dwas.predefined.Package for a better way)
+            step.install(["."])
+
+            # Install a dependency group
+            step.install(["--group=dev"])
+
+            ##
+            # Syncing files from a lockfile
+            ##
+
+            # Install only the package's dependencies but not the package
+            step.install([], sync=True)
+
+            # Install a group of the package
+            step.install(["--only-group=dev"], sync=True)
+
+            # Install the dependencies and a group
+            step.install(["--group=dev"])
+
         :param packages: which packages to install
+        :param sync: Use `uv sync` instead of `pip install` to install the
+                     dependencies. This ensures is resolves dependencies
+                     according to the lock file, and not installing the latest
+                     versions. Note that semantics change a bit, so it is not
+                     fully interchangeable with `sync=False`.
         :param no_deps: ignore the package's dependencies when installing
         :param force_reinstall: force the re-installation of the package and its
                                 dependencies even if already installed
@@ -507,7 +551,10 @@ class StepRunner:
                                   is waiting for it to finish.
         """
         return self._handler.install(
-            *packages, no_deps=no_deps, force_reinstall=force_reinstall
+            *packages,
+            sync=sync,
+            no_deps=no_deps,
+            force_reinstall=force_reinstall,
         )
 
     def run(

--- a/tests/examples/dependencies/dwasfile.py
+++ b/tests/examples/dependencies/dwasfile.py
@@ -7,14 +7,30 @@ dwas.register_managed_step(dwas.predefined.package())
 @dwas.managed_step(None)
 @dwas.parametrize("requires", (["package"], []), ids=("package", "no-package"))
 @dwas.parametrize(
-    "dependencies",
+    ("dependencies", "dependencies_sync"),
     (
-        ["--requirements=pyproject.toml"],
-        ["--group=dev"],
-        ["--group=other"],
-        ["--group=dev", "--group=other", "--requirements=pyproject.toml"],
+        ([], True),
+        (["--requirements=pyproject.toml"], False),
+        (["--only-group=dev"], True),
+        (["--group=dev"], False),
+        (["--only-group=other"], True),
+        (["--group=other"], False),
+        (["--group=dev", "--group=other"], True),
+        (
+            ["--group=dev", "--group=other", "--requirements=pyproject.toml"],
+            False,
+        ),
     ),
-    ids=("pyproject", "dev-group", "other-group", "all"),
+    ids=(
+        "sync,pyproject",
+        "no-sync,pyproject",
+        "sync,dev-group",
+        "no-sync,dev-group",
+        "sync,other-group",
+        "no-sync,other-group",
+        "sync,all",
+        "no-sync,all",
+    ),
 )
 def dependencies(step: dwas.StepRunner) -> None:
     step.run(["uv", "pip", "list", "--format=json"], external_command=True)

--- a/tests/examples/dependencies/uv.lock
+++ b/tests/examples/dependencies/uv.lock
@@ -46,8 +46,8 @@ other = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "colorama", specifier = "==0.4.0" }]
+requires-dist = [{ name = "colorama" }]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pip", specifier = "==25.0" }]
-other = [{ name = "setuptools", specifier = "==70.0.0" }]
+dev = [{ name = "pip" }]
+other = [{ name = "setuptools" }]

--- a/tests/test_dependencies_installation.py
+++ b/tests/test_dependencies_installation.py
@@ -66,15 +66,18 @@ def cache_path(tmp_path_factory):
 @pytest.mark.parametrize(
     "package", (True, False), ids=["package", "no-package"]
 )
+@pytest.mark.parametrize("sync", (True, False), ids=["sync", "no-sync"])
 @using_project("examples/dependencies")
 def test_only_selected_dependencies_are_installed(
     cache_path: Path,
     tmp_path: Path,
     dependencies_name: str,
     package: bool,  # noqa: FBT001
+    sync: bool,  # noqa: FBT001
     expected_packages: dict[str, str],
 ) -> None:
-    step_name = f"dependencies[{'no-' if not package else ''}package,{dependencies_name}]"
+    # pylint: disable=line-too-long
+    step_name = f"dependencies[{'' if package else 'no-'}package,{'' if sync else 'no-'}sync,{dependencies_name}]"
     original_lock = tmp_path.joinpath("uv.lock").read_text()
 
     result = cli(cache_path=cache_path, steps=[step_name])
@@ -82,13 +85,20 @@ def test_only_selected_dependencies_are_installed(
     final_lock = tmp_path.joinpath("uv.lock").read_text()
 
     expected_installs = [
-        {"name": pkg, "version": GreaterThan(version)}
+        {"name": pkg, "version": version if sync else GreaterThan(version)}
         for pkg, version in expected_packages.items()
     ]
     if package:
         if expected_installs[0]["name"] != "colorama":
             expected_installs = [
-                {"name": "colorama", "version": GreaterThan("0.4.0")},
+                {
+                    "name": "colorama",
+                    "version": (
+                        "0.4.0"
+                        if sync and not package
+                        else GreaterThan("0.4.0")
+                    ),
+                },
                 *expected_installs,
             ]
         expected_installs.append(


### PR DESCRIPTION
This leverages `uv sync` to allow users to optionally ensure their dependencies are all pinned