### PR TITLE
Move to ruff instead of unimport, isort and black

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,11 @@ jobs:
       fail-fast: false
       matrix:
         session:
-          - black
           - docformatter
-          - isort
+          - format
           - mypy
           - pylint
           - ruff
-          - unimport
 
     steps:
       - name: Check out repository

--- a/dwasfile.py
+++ b/dwasfile.py
@@ -39,36 +39,16 @@ ARTIFACTS_PATH = ROOT_PATH / "_artifacts"
 # Formatting
 ##
 dwas.register_managed_step(
-    dwas.predefined.unimport(files=PYTHON_FILES),
-    description="Show which imports are unnecessary",
-)
-dwas.register_managed_step(dwas.predefined.isort(files=PYTHON_FILES))
-dwas.register_managed_step(
     dwas.predefined.docformatter(files=PYTHON_FILES),
     dependencies=["docformatter[tomli]"],
 )
-dwas.register_managed_step(dwas.predefined.black())
-dwas.register_step_group(
-    "format-check", ["black", "docformatter", "isort", "unimport"]
+dwas.register_managed_step(
+    dwas.predefined.ruff(additional_arguments=["format", "--diff"]),
+    name="format",
 )
+dwas.register_step_group("format-check", ["format", "docformatter"])
 
 # With auto fix
-dwas.register_managed_step(
-    dwas.predefined.unimport(
-        files=PYTHON_FILES,
-        additional_arguments=["--diff", "--remove", "--check", "--gitignore"],
-    ),
-    name="unimport:fix",
-    run_by_default=False,
-)
-dwas.register_managed_step(
-    dwas.predefined.isort(
-        additional_arguments=["--atomic"], files=PYTHON_FILES
-    ),
-    name="isort:fix",
-    run_by_default=False,
-    requires=["unimport:fix"],
-)
 dwas.register_managed_step(
     dwas.predefined.docformatter(
         additional_arguments=["--recursive", "--diff", "--in-place"],
@@ -78,12 +58,12 @@ dwas.register_managed_step(
     name="docformatter:fix",
     run_by_default=False,
     dependencies=["docformatter[tomli]"],
-    requires=["isort:fix"],
+    requires=[],
 )
 dwas.register_managed_step(
-    dwas.predefined.black(additional_arguments=[]),
-    name="black:fix",
-    requires=["isort:fix", "docformatter:fix"],
+    dwas.predefined.ruff(additional_arguments=["format"]),
+    name="format:fix",
+    requires=["docformatter:fix"],
     run_by_default=False,
 )
 dwas.register_managed_step(
@@ -93,17 +73,15 @@ dwas.register_managed_step(
     ),
     dependencies=["ruff"],
     name="ruff:fix",
-    requires=["black:fix"],
+    requires=["format:fix"],
     run_by_default=False,
 )
 dwas.register_step_group(
     name="fix",
     description="Fix all auto-fixable issues on the project",
     requires=[
-        "unimport:fix",
-        "isort:fix",
         "docformatter:fix",
-        "black:fix",
+        "format:fix",
         "ruff:fix",
     ],
     run_by_default=False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,10 +62,6 @@ optional-dependencies.docs.file = "requirements/requirements-docs.txt"
 ##
 
 ##
-# Black
-[tool.black]
-line-length = 79
-target-version = ["py38"]
 
 ##
 # Docformatter
@@ -76,13 +72,6 @@ make-summary-multi-line = true
 pre-summary-newline = true
 wrap-summaries = 89
 wrap-descriptions = 72
-
-##
-# Isort
-[tool.isort]
-profile = "black"
-line_length = 79
-skip_gitignore = true
 
 ##
 # Mypy
@@ -141,6 +130,7 @@ disable = [
 # Ruff
 [tool.ruff]
 target-version = "py38"
+line-length = 79
 
 [tool.ruff.lint]
 select = ["ALL"]
@@ -151,7 +141,6 @@ ignore = [
     ##
     # Format
     "COM812",  # Don't put trailing commas everywhere
-    "E501",  # line length is handled by black
     ##
     # Docs
     "D200",
@@ -189,6 +178,7 @@ flake8-pytest-style.parametrize-values-type = "tuple"
 flake8-pytest-style.parametrize-values-row-type = "tuple"
 flake8-pytest-style.fixture-parentheses = false
 isort.known-first-party = ["dwas"]
+pycodestyle.max-line-length = 119
 
 [tool.ruff.lint.per-file-ignores]
 "docs/*" = ["D"]

--- a/src/dwas/_io.py
+++ b/src/dwas/_io.py
@@ -68,7 +68,8 @@ class PipePlexer:
         return len(data)
 
     def flush(
-        self, force_write: bool = False  # noqa:FBT001,FBT002
+        self,
+        force_write: bool = False,  # noqa:FBT001,FBT002
     ) -> int | None:
         line = None
 

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -96,9 +96,9 @@ def execute(args: list[str], expected_status: int = 0) -> Result:
         print(out)
         print(err, file=sys.stderr)
 
-    assert (
-        exit_code == expected_status
-    ), f"Unexpected return code {exit_code} != {expected_status} for 'dwas {' '.join(args)}'."
+    assert exit_code == expected_status, (
+        f"Unexpected return code {exit_code} != {expected_status} for 'dwas {' '.join(args)}'."
+    )
     return Result(exc=exception, stdout=out, stderr=err)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,17 +103,17 @@ def ensure_defaults_are_untouched(tmp_path_factory):
     yield
 
     # And validate
-    assert (
-        extract_defaults() == original_values
-    ), "BUG: Defaults arguments were mutated during the tests."
+    assert extract_defaults() == original_values, (
+        "BUG: Defaults arguments were mutated during the tests."
+    )
 
 
 @pytest.fixture
 def project(request, tmp_path, monkeypatch):
     markers = list(request.node.iter_markers("project"))
-    assert (
-        len(markers) == 1
-    ), f"Didn't get the expected number of markers for 'project': {markers}"
+    assert len(markers) == 1, (
+        f"Didn't get the expected number of markers for 'project': {markers}"
+    )
 
     project = markers[0].args[0]
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -218,7 +218,10 @@ def test_only_keeps_dependency_information(pipeline):
     # pylint: disable=protected-access
     assert pipeline._build_graph(
         ["1", "4"], None, only_selected_steps=True
-    ) == {"1": ["4"], "4": []}
+    ) == {
+        "1": ["4"],
+        "4": [],
+    }
 
 
 def test_exclude_keeps_dependency_information(pipeline):
@@ -230,7 +233,10 @@ def test_exclude_keeps_dependency_information(pipeline):
     # pylint: disable=protected-access
     assert pipeline._build_graph(
         None, ["2", "3"], only_selected_steps=False
-    ) == {"1": ["4"], "4": []}
+    ) == {
+        "1": ["4"],
+        "4": [],
+    }
 
 
 @pytest.mark.parametrize("step_type", ("normal", "group"))


### PR DESCRIPTION
They are still supported as predefined steps, but for this project, let's just use ruff. It's overall faster and easier

Main changes are dwasfile.py and pyproject.toml. Rest was changed by running `dwas fix`