### PR TITLE
Add a way to set environment variables in a dependent step

### DIFF
--- a/src/dwas/_runners.py
+++ b/src/dwas/_runners.py
@@ -121,6 +121,9 @@ class VenvRunner:
             silent_on_success=silent_on_success,
         )
 
+    def set_env(self, variable: str, value: str) -> None:
+        self._environ[variable] = value
+
     def _merge_env(
         self, config: Config, additional_env: dict[str, str] | None = None
     ) -> dict[str, str]:

--- a/src/dwas/_steps/handlers.py
+++ b/src/dwas/_steps/handlers.py
@@ -217,6 +217,9 @@ class StepHandler(BaseStepHandler):
         with suppress(FileNotFoundError):
             shutil.rmtree(self._step_runner.cache_path)
 
+    def set_env(self, variable: str, value: str) -> None:
+        self._venv_runner.set_env(variable, value)
+
     def _execute_dependent_setup(self, current_step: BaseStepHandler) -> None:
         assert isinstance(current_step, StepHandler)
 

--- a/src/dwas/_steps/steps.py
+++ b/src/dwas/_steps/steps.py
@@ -603,3 +603,15 @@ class StepRunner:
             external_command=external_command,
             silent_on_success=silent_on_success,
         )
+
+    def set_env(self, variable: str, value: str) -> None:
+        """
+        Set a specific environment variable for this runner.
+
+        This can be useful for example to set environment variables
+        inside another step when setting up a dependent.
+
+        :param variable: The name of the environment variable to set.
+        :param value: The value to set the variable to.
+        """
+        self._handler.set_env(variable, value)

--- a/tests/examples/set_env/dwasfile.py
+++ b/tests/examples/set_env/dwasfile.py
@@ -1,0 +1,23 @@
+import dwas
+
+
+class Step1:
+    __name__ = "step1"
+
+    def setup_dependent(
+        self,
+        original_step: dwas.StepRunner,  # noqa: ARG002
+        current_step: dwas.StepRunner,
+    ) -> None:
+        current_step.set_env("INJECTED_ENV", "foobar")
+
+    def __call__(self, step: dwas.StepRunner) -> None:
+        pass
+
+
+dwas.register_step(Step1())
+
+
+@dwas.step(requires=["step1"])
+def step2(step: dwas.StepRunner) -> None:
+    step.run(["printenv", "INJECTED_ENV"], external_command=True)

--- a/tests/test_env_setting.py
+++ b/tests/test_env_setting.py
@@ -1,0 +1,23 @@
+# pylint: disable=redefined-outer-name
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests._utils import cli, using_project
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(scope="module")
+def cache_path(tmp_path_factory):
+    return tmp_path_factory.mktemp("cache")
+
+
+@using_project("examples/set_env")
+def test_can_inject_environment_in_dependent_steps(cache_path: Path) -> None:
+    result = cli(cache_path=cache_path, steps=["step2"])
+    assert result.stdout == "foobar\n"


### PR DESCRIPTION
This can be useful to inject information into another step without relying on artifacts